### PR TITLE
v0.5.0 Phase 1: Add ProviderFactory and wire RuntimeInsightFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ See [USAGE.md](USAGE.md) for detailed documentation.
 
 Runtime Insight is designed for extensibility:
 
+- **AI Provider Factory** - `ProviderFactory` creates the configured provider (openai; anthropic/ollama in v0.5.0)
 - **Custom AI Providers** - Implement the `AIProviderInterface`
 - **Custom Explanation Strategies** - Add domain-specific patterns
 - **Custom Renderers** - Output to JSON, HTML, Slack, etc.

--- a/USAGE.md
+++ b/USAGE.md
@@ -517,7 +517,11 @@ runtime_insight:
 3. The AI analyzes the error context and returns an explanation
 4. Token usage is tracked for monitoring
 
-### Anthropic (Claude)
+The active provider is chosen from config (`ai.provider`) and instantiated via `ProviderFactory` (used by `RuntimeInsightFactory::createAIProvider`). You can create a provider directly with `ProviderFactory::createProvider($config)`.
+
+### Anthropic (Claude) *(planned for v0.5.0)*
+
+Config structure for when Claude support is added:
 
 ```php
 'ai' => [
@@ -527,7 +531,9 @@ runtime_insight:
 ],
 ```
 
-### Ollama (Local)
+### Ollama (Local) *(planned for v0.5.0)*
+
+Config structure for when Ollama support is added:
 
 ```php
 'ai' => [

--- a/src/AI/ProviderFactory.php
+++ b/src/AI/ProviderFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ClarityPHP\RuntimeInsight\AI;
+
+use ClarityPHP\RuntimeInsight\Config;
+use ClarityPHP\RuntimeInsight\Contracts\AIProviderInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Factory for creating AI provider instances based on configuration.
+ *
+ * Supports: openai (additional providers in later releases).
+ */
+final class ProviderFactory
+{
+    public function __construct(
+        private readonly ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Create an AI provider based on configuration.
+     */
+    public function create(Config $config): ?AIProviderInterface
+    {
+        $provider = $config->getAIProvider();
+
+        return match ($provider) {
+            'openai' => new OpenAIProvider($config, $this->logger),
+            default => null,
+        };
+    }
+
+    /**
+     * Create an AI provider (static convenience method).
+     */
+    public static function createProvider(Config $config, ?LoggerInterface $logger = null): ?AIProviderInterface
+    {
+        $factory = new self($logger);
+
+        return $factory->create($config);
+    }
+}

--- a/src/RuntimeInsightFactory.php
+++ b/src/RuntimeInsightFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ClarityPHP\RuntimeInsight;
 
-use ClarityPHP\RuntimeInsight\AI\OpenAIProvider;
+use ClarityPHP\RuntimeInsight\AI\ProviderFactory;
 use ClarityPHP\RuntimeInsight\Context\ContextBuilder;
 use ClarityPHP\RuntimeInsight\Contracts\AIProviderInterface;
 use ClarityPHP\RuntimeInsight\Contracts\ContextBuilderInterface;
@@ -80,11 +80,6 @@ final class RuntimeInsightFactory
      */
     public static function createAIProvider(Config $config): ?AIProviderInterface
     {
-        $provider = $config->getAIProvider();
-
-        return match ($provider) {
-            'openai' => new OpenAIProvider($config),
-            default => null,
-        };
+        return ProviderFactory::createProvider($config);
     }
 }

--- a/tests/Unit/AI/ProviderFactoryTest.php
+++ b/tests/Unit/AI/ProviderFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ClarityPHP\RuntimeInsight\Tests\Unit\AI;
+
+use ClarityPHP\RuntimeInsight\AI\OpenAIProvider;
+use ClarityPHP\RuntimeInsight\AI\ProviderFactory;
+use ClarityPHP\RuntimeInsight\Config;
+use PHPUnit\Framework\TestCase;
+
+final class ProviderFactoryTest extends TestCase
+{
+    public function test_create_returns_openai_provider_when_configured(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'openai',
+            aiApiKey: 'test-key',
+        );
+
+        $factory = new ProviderFactory();
+        $provider = $factory->create($config);
+
+        $this->assertInstanceOf(OpenAIProvider::class, $provider);
+        $this->assertSame('openai', $provider->getName());
+    }
+
+    public function test_create_returns_null_for_unknown_provider(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'unknown',
+        );
+
+        $factory = new ProviderFactory();
+        $provider = $factory->create($config);
+
+        $this->assertNull($provider);
+    }
+
+    public function test_create_provider_static_returns_openai_provider(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'openai',
+            aiApiKey: 'test-key',
+        );
+
+        $provider = ProviderFactory::createProvider($config);
+
+        $this->assertInstanceOf(OpenAIProvider::class, $provider);
+    }
+
+    public function test_create_provider_static_returns_null_for_unknown(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'future-provider',
+        );
+
+        $provider = ProviderFactory::createProvider($config);
+
+        $this->assertNull($provider);
+    }
+}


### PR DESCRIPTION
- Add AI\ProviderFactory for creating providers from config (openai)
- RuntimeInsightFactory::createAIProvider uses ProviderFactory
- Add ProviderFactoryTest (4 tests)
- Update README (ProviderFactory in extensibility)
- Update USAGE (ProviderFactory, anthropic/ollama marked planned)