### PR TITLE
v0.5.0 Phase 2: Add Anthropic Claude provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ See [USAGE.md](USAGE.md) for detailed documentation.
 
 Runtime Insight is designed for extensibility:
 
-- **AI Provider Factory** - `ProviderFactory` creates the configured provider (openai; anthropic/ollama in v0.5.0)
+- **AI Provider Factory** - `ProviderFactory` creates the configured provider (openai, anthropic; ollama in v0.5.0)
 - **Custom AI Providers** - Implement the `AIProviderInterface`
 - **Custom Explanation Strategies** - Add domain-specific patterns
 - **Custom Renderers** - Output to JSON, HTML, Slack, etc.

--- a/USAGE.md
+++ b/USAGE.md
@@ -519,17 +519,45 @@ runtime_insight:
 
 The active provider is chosen from config (`ai.provider`) and instantiated via `ProviderFactory` (used by `RuntimeInsightFactory::createAIProvider`). You can create a provider directly with `ProviderFactory::createProvider($config)`.
 
-### Anthropic (Claude) *(planned for v0.5.0)*
+### Anthropic (Claude)
 
-Config structure for when Claude support is added:
+The Anthropic provider uses the Claude Messages API for error analysis. Set `ai.provider` to `anthropic` and your Anthropic API key.
+
+**Configuration:**
 
 ```php
+// config/runtime-insight.php (Laravel)
 'ai' => [
+    'enabled' => true,
     'provider' => 'anthropic',
-    'model' => 'claude-sonnet-4-20250514',
-    'api_key' => env('ANTHROPIC_API_KEY'),
+    'model' => 'claude-sonnet-4-20250514',  // or claude-3-5-haiku-20241022, claude-3-opus-latest, etc.
+    'api_key' => env('RUNTIME_INSIGHT_AI_KEY'),  // or ANTHROPIC_API_KEY
+    'timeout' => 5,
 ],
 ```
+
+```yaml
+# config/packages/runtime_insight.yaml (Symfony)
+runtime_insight:
+    ai:
+        enabled: true
+        provider: anthropic
+        model: claude-sonnet-4-20250514
+        api_key: '%env(RUNTIME_INSIGHT_AI_KEY)%'
+        timeout: 5
+```
+
+**Features:**
+- Messages API with system prompt and user message
+- Retry with exponential backoff on rate limits (429)
+- Token usage tracking (input + output) in explanation metadata
+- Same JSON response format as OpenAI for consistent parsing
+
+**How it works:**
+1. Rule-based strategies are tried first
+2. If no strategy matches and AI is enabled, the Anthropic Messages API is called
+3. Claude analyzes the error context and returns an explanation (JSON or fallback text)
+4. Token usage is recorded in metadata
 
 ### Ollama (Local) *(planned for v0.5.0)*
 

--- a/src/AI/AnthropicProvider.php
+++ b/src/AI/AnthropicProvider.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ClarityPHP\RuntimeInsight\AI;
+
+use ClarityPHP\RuntimeInsight\Config;
+use ClarityPHP\RuntimeInsight\Contracts\AIProviderInterface;
+use ClarityPHP\RuntimeInsight\DTO\Explanation;
+use ClarityPHP\RuntimeInsight\DTO\RuntimeContext;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\RequestOptions;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+use function is_array;
+use function is_int;
+use function is_string;
+use function json_decode;
+use function sleep;
+use function str_contains;
+use function str_starts_with;
+
+/**
+ * Anthropic Claude provider for AI-powered error analysis.
+ */
+final class AnthropicProvider implements AIProviderInterface
+{
+    private const API_BASE_URL = 'https://api.anthropic.com/v1';
+
+    private const API_VERSION = '2023-06-01';
+
+    private const MAX_RETRIES = 3;
+
+    private const RETRY_DELAY = 1;
+
+    private const DEFAULT_MAX_TOKENS = 1000;
+
+    public function __construct(
+        private readonly Config $config,
+        private readonly ?LoggerInterface $logger = null,
+        private readonly ?Client $httpClient = null,
+    ) {}
+
+    public function analyze(RuntimeContext $context): Explanation
+    {
+        if (! $this->isAvailable()) {
+            return Explanation::empty();
+        }
+
+        try {
+            $response = $this->makeRequest($context);
+
+            return $this->parseResponse($response, $context);
+        } catch (Throwable $e) {
+            $this->logError('Anthropic API error', $e);
+
+            return Explanation::empty();
+        }
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->config->isAIEnabled()
+            && $this->config->getAIProvider() === 'anthropic'
+            && $this->config->getAIApiKey() !== null
+            && $this->config->getAIApiKey() !== '';
+    }
+
+    public function getName(): string
+    {
+        return 'anthropic';
+    }
+
+    /**
+     * Make API request to Anthropic Messages API with retry logic.
+     *
+     * @return array<string, mixed>
+     */
+    private function makeRequest(RuntimeContext $context): array
+    {
+        $client = $this->httpClient ?? new Client([
+            'base_uri' => self::API_BASE_URL . '/',
+            'timeout' => $this->config->getAITimeout(),
+        ]);
+
+        $prompt = $this->buildPrompt($context);
+        $payload = [
+            'model' => $this->config->getAIModel(),
+            'max_tokens' => self::DEFAULT_MAX_TOKENS,
+            'system' => $this->getSystemPrompt(),
+            'messages' => [
+                [
+                    'role' => 'user',
+                    'content' => $prompt,
+                ],
+            ],
+        ];
+
+        $retries = 0;
+        $lastException = null;
+
+        while ($retries < self::MAX_RETRIES) {
+            try {
+                $response = $client->post('messages', [
+                    RequestOptions::HEADERS => [
+                        'Content-Type' => 'application/json',
+                        'anthropic-version' => self::API_VERSION,
+                        'x-api-key' => $this->config->getAIApiKey(),
+                    ],
+                    RequestOptions::JSON => $payload,
+                ]);
+
+                $body = $response->getBody()->getContents();
+                $data = json_decode($body, true);
+
+                if (! is_array($data)) {
+                    throw new RuntimeException('Invalid response from Anthropic API');
+                }
+
+                /** @var array<string, mixed> $data */
+                return $data;
+            } catch (GuzzleException $e) {
+                $lastException = $e;
+
+                $isRateLimit = false;
+                if ($e instanceof ClientException || $e instanceof ServerException) {
+                    if ($e->getResponse()->getStatusCode() === 429) {
+                        $isRateLimit = true;
+                    }
+                } elseif ($e->getCode() === 429) {
+                    $isRateLimit = true;
+                }
+
+                if ($isRateLimit) {
+                    $retries++;
+                    if ($retries < self::MAX_RETRIES) {
+                        $delay = self::RETRY_DELAY * $retries;
+                        sleep($delay);
+                        continue;
+                    }
+                }
+
+                throw $e;
+            }
+        }
+
+        if ($lastException !== null) {
+            throw $lastException;
+        }
+
+        throw new RuntimeException('Failed to get response from Anthropic API');
+    }
+
+    private function buildPrompt(RuntimeContext $context): string
+    {
+        $prompt = "Analyze this PHP runtime error and provide a clear explanation.\n\n";
+        $prompt .= "Exception Type: {$context->exception->class}\n";
+        $prompt .= "Error Message: {$context->exception->message}\n";
+        $prompt .= "File: {$context->exception->file}\n";
+        $prompt .= "Line: {$context->exception->line}\n\n";
+
+        if ($context->sourceContext->codeSnippet !== '') {
+            $prompt .= "Source Code Context:\n```php\n{$context->sourceContext->codeSnippet}\n```\n\n";
+        }
+
+        if ($context->stackTrace->frames !== []) {
+            $prompt .= "Stack Trace (first 5 frames):\n";
+            $frameCount = 0;
+            foreach ($context->stackTrace->frames as $frame) {
+                if ($frameCount >= 5) {
+                    break;
+                }
+                $prompt .= "  - {$frame->file}:{$frame->line} in {$frame->class}{$frame->type}{$frame->function}\n";
+                $frameCount++;
+            }
+            $prompt .= "\n";
+        }
+
+        if ($context->requestContext !== null) {
+            $prompt .= "Request: {$context->requestContext->method} {$context->requestContext->uri}\n";
+        }
+
+        $prompt .= "\nProvide your response in JSON format with the following structure: ";
+        $prompt .= '{"message": "Brief error summary", "cause": "Root cause explanation", ';
+        $prompt .= '"suggestions": ["Fix 1", "Fix 2"], "confidence": 0.85}';
+
+        return $prompt;
+    }
+
+    private function getSystemPrompt(): string
+    {
+        return 'You are an expert PHP developer helping to debug runtime errors. '
+            . 'Analyze the provided error information and provide clear, actionable explanations. '
+            . 'Focus on the root cause and provide specific fix suggestions. '
+            . 'Respond only with valid JSON in the requested structure.';
+    }
+
+    /**
+     * Parse Anthropic API response into Explanation.
+     *
+     * @param array<string, mixed> $response
+     */
+    private function parseResponse(array $response, RuntimeContext $context): Explanation
+    {
+        $content = $response['content'] ?? [];
+        if (! is_array($content) || $content === []) {
+            return Explanation::empty();
+        }
+
+        $text = '';
+        foreach ($content as $block) {
+            if (! is_array($block)) {
+                continue;
+            }
+            $type = $block['type'] ?? null;
+            if ($type === 'text' && isset($block['text']) && is_string($block['text'])) {
+                $text .= $block['text'];
+            }
+        }
+
+        if ($text === '') {
+            return Explanation::empty();
+        }
+
+        $parsed = json_decode($text, true);
+
+        if (! is_array($parsed)) {
+            return $this->parseTextResponse($text, $context);
+        }
+
+        $suggestions = [];
+        if (isset($parsed['suggestions']) && is_array($parsed['suggestions'])) {
+            foreach ($parsed['suggestions'] as $suggestion) {
+                if (is_string($suggestion)) {
+                    $suggestions[] = $suggestion;
+                }
+            }
+        }
+
+        $tokensUsed = null;
+        if (isset($response['usage']) && is_array($response['usage'])) {
+            $usage = $response['usage'];
+            $input = $usage['input_tokens'] ?? null;
+            $output = $usage['output_tokens'] ?? null;
+            if (is_int($input) && is_int($output)) {
+                $tokensUsed = $input + $output;
+            }
+        }
+
+        return new Explanation(
+            message: is_string($parsed['message'] ?? null) ? $parsed['message'] : $context->exception->message,
+            cause: is_string($parsed['cause'] ?? null) ? $parsed['cause'] : 'Unable to determine root cause',
+            suggestions: $suggestions,
+            confidence: isset($parsed['confidence']) && is_numeric($parsed['confidence']) ? (float) $parsed['confidence'] : 0.7,
+            errorType: $context->exception->class,
+            location: "{$context->exception->file}:{$context->exception->line}",
+            metadata: [
+                'provider' => 'anthropic',
+                'model' => $this->config->getAIModel(),
+                'tokens_used' => $tokensUsed,
+            ],
+        );
+    }
+
+    private function parseTextResponse(string $content, RuntimeContext $context): Explanation
+    {
+        $suggestions = [];
+        $lines = explode("\n", $content);
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || str_contains($line, ':')) {
+                continue;
+            }
+            if (str_starts_with($line, '-') || str_starts_with($line, '*')) {
+                $suggestions[] = trim($line, '-* ');
+            }
+        }
+
+        return new Explanation(
+            message: $context->exception->message,
+            cause: $content,
+            suggestions: $suggestions !== [] ? $suggestions : ['Review the error message and stack trace'],
+            confidence: 0.6,
+            errorType: $context->exception->class,
+            location: "{$context->exception->file}:{$context->exception->line}",
+        );
+    }
+
+    private function logError(string $message, Throwable $e): void
+    {
+        if ($this->logger !== null) {
+            $this->logger->error($message, [
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/AI/ProviderFactory.php
+++ b/src/AI/ProviderFactory.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Factory for creating AI provider instances based on configuration.
  *
- * Supports: openai (additional providers in later releases).
+ * Supports: openai, anthropic (ollama in later releases).
  */
 final class ProviderFactory
 {
@@ -28,6 +28,7 @@ final class ProviderFactory
 
         return match ($provider) {
             'openai' => new OpenAIProvider($config, $this->logger),
+            'anthropic' => new AnthropicProvider($config, $this->logger),
             default => null,
         };
     }

--- a/tests/Unit/AI/AnthropicProviderTest.php
+++ b/tests/Unit/AI/AnthropicProviderTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ClarityPHP\RuntimeInsight\Tests\Unit\AI;
+
+use ClarityPHP\RuntimeInsight\AI\AnthropicProvider;
+use ClarityPHP\RuntimeInsight\Config;
+use ClarityPHP\RuntimeInsight\DTO\ExceptionInfo;
+use ClarityPHP\RuntimeInsight\DTO\RuntimeContext;
+use ClarityPHP\RuntimeInsight\DTO\SourceContext;
+use ClarityPHP\RuntimeInsight\DTO\StackTraceInfo;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class AnthropicProviderTest extends TestCase
+{
+    private Config $config;
+
+    private LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'anthropic',
+            aiApiKey: 'test-api-key',
+            aiModel: 'claude-sonnet-4-20250514',
+        );
+
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    public function test_it_returns_empty_when_not_available(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: false,
+        );
+
+        $provider = new AnthropicProvider($config);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function test_it_returns_empty_when_api_key_missing(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'anthropic',
+            aiApiKey: null,
+        );
+
+        $provider = new AnthropicProvider($config);
+
+        $this->assertFalse($provider->isAvailable());
+    }
+
+    public function test_it_is_available_when_properly_configured(): void
+    {
+        $provider = new AnthropicProvider($this->config);
+
+        $this->assertTrue($provider->isAvailable());
+        $this->assertSame('anthropic', $provider->getName());
+    }
+
+    public function test_it_parses_json_response_correctly(): void
+    {
+        $jsonContent = json_encode([
+            'message' => 'Test error message',
+            'cause' => 'Root cause explanation',
+            'suggestions' => ['Fix 1', 'Fix 2'],
+            'confidence' => 0.85,
+        ], JSON_THROW_ON_ERROR);
+
+        $mockResponse = [
+            'content' => [
+                ['type' => 'text', 'text' => $jsonContent],
+            ],
+            'usage' => [
+                'input_tokens' => 100,
+                'output_tokens' => 50,
+            ],
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($mockResponse)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $provider = new AnthropicProvider($this->config, null, $client);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertFalse($result->isEmpty());
+        $this->assertSame('Test error message', $result->getMessage());
+        $this->assertSame('Root cause explanation', $result->getCause());
+        $this->assertCount(2, $result->getSuggestions());
+        $this->assertSame(0.85, $result->getConfidence());
+        $this->assertSame(150, $result->getMetadata()['tokens_used']);
+    }
+
+    public function test_it_handles_text_response_when_json_fails(): void
+    {
+        $mockResponse = [
+            'content' => [
+                ['type' => 'text', 'text' => 'This is a text response without JSON'],
+            ],
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($mockResponse)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $provider = new AnthropicProvider($this->config, null, $client);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertFalse($result->isEmpty());
+        $this->assertStringContainsString('text response', $result->getCause());
+    }
+
+    public function test_it_handles_api_errors_gracefully(): void
+    {
+        $mock = new MockHandler([
+            new ClientException('API Error', new Request('POST', 'messages'), new Response(500)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $this->logger
+            ->expects($this->once())
+            ->method('error');
+
+        $provider = new AnthropicProvider($this->config, $this->logger, $client);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function test_it_handles_empty_content(): void
+    {
+        $mockResponse = [
+            'content' => [],
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($mockResponse)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $provider = new AnthropicProvider($this->config, null, $client);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function test_it_is_not_available_when_provider_is_openai(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'openai',
+            aiApiKey: 'key',
+        );
+
+        $provider = new AnthropicProvider($config);
+
+        $this->assertFalse($provider->isAvailable());
+    }
+
+    private function createMockContext(): RuntimeContext
+    {
+        $exception = new Exception('Test error');
+        $exceptionInfo = ExceptionInfo::fromThrowable($exception);
+
+        return new RuntimeContext(
+            exception: $exceptionInfo,
+            stackTrace: new StackTraceInfo([]),
+            sourceContext: SourceContext::empty(),
+        );
+    }
+}

--- a/tests/Unit/AI/ProviderFactoryTest.php
+++ b/tests/Unit/AI/ProviderFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ClarityPHP\RuntimeInsight\Tests\Unit\AI;
 
+use ClarityPHP\RuntimeInsight\AI\AnthropicProvider;
 use ClarityPHP\RuntimeInsight\AI\OpenAIProvider;
 use ClarityPHP\RuntimeInsight\AI\ProviderFactory;
 use ClarityPHP\RuntimeInsight\Config;
@@ -25,6 +26,22 @@ final class ProviderFactoryTest extends TestCase
 
         $this->assertInstanceOf(OpenAIProvider::class, $provider);
         $this->assertSame('openai', $provider->getName());
+    }
+
+    public function test_create_returns_anthropic_provider_when_configured(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'anthropic',
+            aiApiKey: 'test-key',
+        );
+
+        $factory = new ProviderFactory();
+        $provider = $factory->create($config);
+
+        $this->assertInstanceOf(AnthropicProvider::class, $provider);
+        $this->assertSame('anthropic', $provider->getName());
     }
 
     public function test_create_returns_null_for_unknown_provider(): void


### PR DESCRIPTION
- Add AI\AnthropicProvider (Messages API, retry, token tracking)
- Register anthropic in ProviderFactory
- Add AnthropicProviderTest (8 tests) and ProviderFactoryTest for anthropic
- Update README and USAGE with Anthropic (Claude) docs and config