### PR TITLE
v0.5.0 Phase 3: Add Ollama provider and Config base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ See [USAGE.md](USAGE.md) for detailed documentation.
 
 Runtime Insight is designed for extensibility:
 
-- **AI Provider Factory** - `ProviderFactory` creates the configured provider (openai, anthropic; ollama in v0.5.0)
+- **AI Provider Factory** - `ProviderFactory` creates the configured provider (openai, anthropic, ollama)
 - **Custom AI Providers** - Implement the `AIProviderInterface`
 - **Custom Explanation Strategies** - Add domain-specific patterns
 - **Custom Renderers** - Output to JSON, HTML, Slack, etc.

--- a/USAGE.md
+++ b/USAGE.md
@@ -559,17 +559,48 @@ runtime_insight:
 3. Claude analyzes the error context and returns an explanation (JSON or fallback text)
 4. Token usage is recorded in metadata
 
-### Ollama (Local) *(planned for v0.5.0)*
+### Ollama (Local)
 
-Config structure for when Ollama support is added:
+The Ollama provider uses your local Ollama server for error analysis. No API key is required. Set `ai.provider` to `ollama` and optionally `ai.base_url` if Ollama is not on the default host/port.
+
+**Configuration:**
 
 ```php
+// config/runtime-insight.php (Laravel)
 'ai' => [
+    'enabled' => true,
     'provider' => 'ollama',
-    'model' => 'llama3.2',
-    'base_url' => 'http://localhost:11434',
+    'model' => 'llama3.2',  // or llama3.1, codellama, mistral, etc.
+    'base_url' => env('RUNTIME_INSIGHT_AI_BASE_URL', 'http://localhost:11434'),
+    'timeout' => 30,  // local models may need longer
 ],
 ```
+
+```yaml
+# config/packages/runtime_insight.yaml (Symfony)
+runtime_insight:
+    ai:
+        enabled: true
+        provider: ollama
+        model: llama3.2
+        base_url: '%env(default::RUNTIME_INSIGHT_AI_BASE_URL)%'
+        timeout: 30
+```
+
+**Features:**
+- No API key required (local inference)
+- Uses Ollama `/api/chat` with JSON format
+- Configurable base URL (default `http://localhost:11434`)
+- Eval counts in explanation metadata (`eval_count`, `prompt_eval_count`)
+- Same JSON response shape as other providers for consistent parsing
+
+**How it works:**
+1. Rule-based strategies are tried first
+2. If no strategy matches and AI is enabled, the Ollama chat API is called
+3. The model analyzes the error context and returns an explanation (JSON or fallback text)
+4. Token/eval counts are recorded in metadata
+
+**Prerequisites:** Run [Ollama](https://ollama.com) locally and pull a model (e.g. `ollama pull llama3.2`).
 
 ### Custom Provider
 

--- a/src/AI/OllamaProvider.php
+++ b/src/AI/OllamaProvider.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ClarityPHP\RuntimeInsight\AI;
+
+use ClarityPHP\RuntimeInsight\Config;
+use ClarityPHP\RuntimeInsight\Contracts\AIProviderInterface;
+use ClarityPHP\RuntimeInsight\DTO\Explanation;
+use ClarityPHP\RuntimeInsight\DTO\RuntimeContext;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+use function is_array;
+use function is_int;
+use function is_string;
+use function json_decode;
+use function rtrim;
+use function str_contains;
+use function str_starts_with;
+
+/**
+ * Ollama provider for local AI-powered error analysis.
+ *
+ * Uses the Ollama /api/chat endpoint. No API key required.
+ */
+final class OllamaProvider implements AIProviderInterface
+{
+    private const DEFAULT_BASE_URL = 'http://localhost:11434';
+
+    public function __construct(
+        private readonly Config $config,
+        private readonly ?LoggerInterface $logger = null,
+        private readonly ?Client $httpClient = null,
+    ) {}
+
+    public function analyze(RuntimeContext $context): Explanation
+    {
+        if (! $this->isAvailable()) {
+            return Explanation::empty();
+        }
+
+        try {
+            $response = $this->makeRequest($context);
+
+            return $this->parseResponse($response, $context);
+        } catch (Throwable $e) {
+            $this->logError('Ollama API error', $e);
+
+            return Explanation::empty();
+        }
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->config->isAIConfigured()
+            && $this->config->getAIProvider() === 'ollama';
+    }
+
+    public function getName(): string
+    {
+        return 'ollama';
+    }
+
+    private function getBaseUrl(): string
+    {
+        $url = $this->config->getAIBaseUrl();
+
+        return $url !== null && $url !== '' ? rtrim($url, '/') : self::DEFAULT_BASE_URL;
+    }
+
+    /**
+     * Make API request to Ollama /api/chat.
+     *
+     * @return array<string, mixed>
+     */
+    private function makeRequest(RuntimeContext $context): array
+    {
+        $baseUrl = $this->getBaseUrl();
+        $client = $this->httpClient ?? new Client([
+            'base_uri' => $baseUrl . '/',
+            'timeout' => $this->config->getAITimeout(),
+        ]);
+
+        $prompt = $this->buildPrompt($context);
+        $payload = [
+            'model' => $this->config->getAIModel(),
+            'messages' => [
+                [
+                    'role' => 'system',
+                    'content' => $this->getSystemPrompt(),
+                ],
+                [
+                    'role' => 'user',
+                    'content' => $prompt,
+                ],
+            ],
+            'stream' => false,
+            'format' => 'json',
+        ];
+
+        $response = $client->post('api/chat', [
+            RequestOptions::JSON => $payload,
+        ]);
+
+        $body = $response->getBody()->getContents();
+        $data = json_decode($body, true);
+
+        if (! is_array($data)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $data */
+        return $data;
+    }
+
+    private function buildPrompt(RuntimeContext $context): string
+    {
+        $prompt = "Analyze this PHP runtime error and provide a clear explanation.\n\n";
+        $prompt .= "Exception Type: {$context->exception->class}\n";
+        $prompt .= "Error Message: {$context->exception->message}\n";
+        $prompt .= "File: {$context->exception->file}\n";
+        $prompt .= "Line: {$context->exception->line}\n\n";
+
+        if ($context->sourceContext->codeSnippet !== '') {
+            $prompt .= "Source Code Context:\n```php\n{$context->sourceContext->codeSnippet}\n```\n\n";
+        }
+
+        if ($context->stackTrace->frames !== []) {
+            $prompt .= "Stack Trace (first 5 frames):\n";
+            $frameCount = 0;
+            foreach ($context->stackTrace->frames as $frame) {
+                if ($frameCount >= 5) {
+                    break;
+                }
+                $prompt .= "  - {$frame->file}:{$frame->line} in {$frame->class}{$frame->type}{$frame->function}\n";
+                $frameCount++;
+            }
+            $prompt .= "\n";
+        }
+
+        if ($context->requestContext !== null) {
+            $prompt .= "Request: {$context->requestContext->method} {$context->requestContext->uri}\n";
+        }
+
+        $prompt .= "\nRespond with valid JSON only: ";
+        $prompt .= '{"message": "Brief error summary", "cause": "Root cause explanation", ';
+        $prompt .= '"suggestions": ["Fix 1", "Fix 2"], "confidence": 0.85}';
+
+        return $prompt;
+    }
+
+    private function getSystemPrompt(): string
+    {
+        return 'You are an expert PHP developer helping to debug runtime errors. '
+            . 'Analyze the provided error information and respond only with valid JSON in this exact structure: '
+            . '{"message": "string", "cause": "string", "suggestions": ["string"], "confidence": number}.';
+    }
+
+    /**
+     * Parse Ollama API response into Explanation.
+     *
+     * @param array<string, mixed> $response
+     */
+    private function parseResponse(array $response, RuntimeContext $context): Explanation
+    {
+        $message = $response['message'] ?? null;
+        if (! is_array($message) || ! isset($message['content']) || ! is_string($message['content'])) {
+            return Explanation::empty();
+        }
+
+        $content = $message['content'];
+        if ($content === '') {
+            return Explanation::empty();
+        }
+        $parsed = json_decode($content, true);
+
+        if (! is_array($parsed)) {
+            return $this->parseTextResponse($content, $context);
+        }
+
+        $suggestions = [];
+        if (isset($parsed['suggestions']) && is_array($parsed['suggestions'])) {
+            foreach ($parsed['suggestions'] as $suggestion) {
+                if (is_string($suggestion)) {
+                    $suggestions[] = $suggestion;
+                }
+            }
+        }
+
+        $evalCount = null;
+        if (isset($response['eval_count']) && is_int($response['eval_count'])) {
+            $evalCount = $response['eval_count'];
+        }
+        $promptEvalCount = null;
+        if (isset($response['prompt_eval_count']) && is_int($response['prompt_eval_count'])) {
+            $promptEvalCount = $response['prompt_eval_count'];
+        }
+
+        return new Explanation(
+            message: is_string($parsed['message'] ?? null) ? $parsed['message'] : $context->exception->message,
+            cause: is_string($parsed['cause'] ?? null) ? $parsed['cause'] : 'Unable to determine root cause',
+            suggestions: $suggestions,
+            confidence: isset($parsed['confidence']) && is_numeric($parsed['confidence']) ? (float) $parsed['confidence'] : 0.7,
+            errorType: $context->exception->class,
+            location: "{$context->exception->file}:{$context->exception->line}",
+            metadata: [
+                'provider' => 'ollama',
+                'model' => $this->config->getAIModel(),
+                'eval_count' => $evalCount,
+                'prompt_eval_count' => $promptEvalCount,
+            ],
+        );
+    }
+
+    private function parseTextResponse(string $content, RuntimeContext $context): Explanation
+    {
+        $suggestions = [];
+        $lines = explode("\n", $content);
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || str_contains($line, ':')) {
+                continue;
+            }
+            if (str_starts_with($line, '-') || str_starts_with($line, '*')) {
+                $suggestions[] = trim($line, '-* ');
+            }
+        }
+
+        return new Explanation(
+            message: $context->exception->message,
+            cause: $content,
+            suggestions: $suggestions !== [] ? $suggestions : ['Review the error message and stack trace'],
+            confidence: 0.6,
+            errorType: $context->exception->class,
+            location: "{$context->exception->file}:{$context->exception->line}",
+        );
+    }
+
+    private function logError(string $message, Throwable $e): void
+    {
+        if ($this->logger !== null) {
+            $this->logger->error($message, [
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/AI/ProviderFactory.php
+++ b/src/AI/ProviderFactory.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Factory for creating AI provider instances based on configuration.
  *
- * Supports: openai, anthropic (ollama in later releases).
+ * Supports: openai, anthropic, ollama.
  */
 final class ProviderFactory
 {
@@ -29,6 +29,7 @@ final class ProviderFactory
         return match ($provider) {
             'openai' => new OpenAIProvider($config, $this->logger),
             'anthropic' => new AnthropicProvider($config, $this->logger),
+            'ollama' => new OllamaProvider($config, $this->logger),
             default => null,
         };
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -26,6 +26,7 @@ final readonly class Config
         private string $aiProvider = 'openai',
         private string $aiModel = 'gpt-4.1-mini',
         private ?string $aiApiKey = null,
+        private ?string $aiBaseUrl = null,
         private int $aiTimeout = 5,
         private int $sourceLines = 10,
         private bool $includeRequest = true,
@@ -49,6 +50,7 @@ final readonly class Config
         $aiProvider = $ai['provider'] ?? 'openai';
         $aiModel = $ai['model'] ?? 'gpt-4.1-mini';
         $aiApiKey = $ai['api_key'] ?? null;
+        $aiBaseUrl = $ai['base_url'] ?? null;
         $aiTimeout = $ai['timeout'] ?? 5;
         $sourceLines = $context['source_lines'] ?? 10;
         $includeRequest = $context['include_request'] ?? true;
@@ -64,6 +66,7 @@ final readonly class Config
             aiProvider: is_string($aiProvider) ? $aiProvider : 'openai',
             aiModel: is_string($aiModel) ? $aiModel : 'gpt-4.1-mini',
             aiApiKey: is_string($aiApiKey) ? $aiApiKey : null,
+            aiBaseUrl: is_string($aiBaseUrl) ? $aiBaseUrl : null,
             aiTimeout: is_int($aiTimeout) ? $aiTimeout : 5,
             sourceLines: is_int($sourceLines) ? $sourceLines : 10,
             includeRequest: is_bool($includeRequest) ? $includeRequest : true,
@@ -118,6 +121,11 @@ final readonly class Config
     public function getAIApiKey(): ?string
     {
         return $this->aiApiKey;
+    }
+
+    public function getAIBaseUrl(): ?string
+    {
+        return $this->aiBaseUrl;
     }
 
     public function getAITimeout(): int

--- a/tests/Unit/AI/OllamaProviderTest.php
+++ b/tests/Unit/AI/OllamaProviderTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ClarityPHP\RuntimeInsight\Tests\Unit\AI;
+
+use ClarityPHP\RuntimeInsight\AI\OllamaProvider;
+use ClarityPHP\RuntimeInsight\Config;
+use ClarityPHP\RuntimeInsight\DTO\ExceptionInfo;
+use ClarityPHP\RuntimeInsight\DTO\RuntimeContext;
+use ClarityPHP\RuntimeInsight\DTO\SourceContext;
+use ClarityPHP\RuntimeInsight\DTO\StackTraceInfo;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class OllamaProviderTest extends TestCase
+{
+    private Config $config;
+
+    private LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'ollama',
+            aiModel: 'llama3.2',
+        );
+
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    public function test_it_returns_empty_when_not_available(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: false,
+        );
+
+        $provider = new OllamaProvider($config);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function test_it_is_available_when_properly_configured(): void
+    {
+        $provider = new OllamaProvider($this->config);
+
+        $this->assertTrue($provider->isAvailable());
+        $this->assertSame('ollama', $provider->getName());
+    }
+
+    public function test_it_parses_json_response_correctly(): void
+    {
+        $jsonContent = json_encode([
+            'message' => 'Test error message',
+            'cause' => 'Root cause explanation',
+            'suggestions' => ['Fix 1', 'Fix 2'],
+            'confidence' => 0.85,
+        ], JSON_THROW_ON_ERROR);
+
+        $mockResponse = [
+            'message' => [
+                'role' => 'assistant',
+                'content' => $jsonContent,
+            ],
+            'eval_count' => 50,
+            'prompt_eval_count' => 100,
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($mockResponse)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $provider = new OllamaProvider($this->config, null, $client);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertFalse($result->isEmpty());
+        $this->assertSame('Test error message', $result->getMessage());
+        $this->assertSame('Root cause explanation', $result->getCause());
+        $this->assertCount(2, $result->getSuggestions());
+        $this->assertSame(0.85, $result->getConfidence());
+        $this->assertSame(50, $result->getMetadata()['eval_count']);
+        $this->assertSame(100, $result->getMetadata()['prompt_eval_count']);
+    }
+
+    public function test_it_handles_text_response_when_json_fails(): void
+    {
+        $mockResponse = [
+            'message' => [
+                'role' => 'assistant',
+                'content' => 'This is a text response without JSON',
+            ],
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($mockResponse)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $provider = new OllamaProvider($this->config, null, $client);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertFalse($result->isEmpty());
+        $this->assertStringContainsString('text response', $result->getCause());
+    }
+
+    public function test_it_handles_api_errors_gracefully(): void
+    {
+        $mock = new MockHandler([
+            new ConnectException('Connection refused', new Request('POST', 'api/chat')),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $this->logger
+            ->expects($this->once())
+            ->method('error');
+
+        $provider = new OllamaProvider($this->config, $this->logger, $client);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function test_it_handles_empty_message_content(): void
+    {
+        $mockResponse = [
+            'message' => [
+                'role' => 'assistant',
+                'content' => '',
+            ],
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($mockResponse)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handlerStack]);
+
+        $provider = new OllamaProvider($this->config, null, $client);
+        $context = $this->createMockContext();
+
+        $result = $provider->analyze($context);
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function test_it_uses_custom_base_url_from_config(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'ollama',
+            aiModel: 'llama3.2',
+            aiBaseUrl: 'http://ollama.example.com:11434',
+        );
+
+        $provider = new OllamaProvider($config);
+
+        $this->assertTrue($provider->isAvailable());
+    }
+
+    public function test_it_is_not_available_when_provider_is_openai(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'openai',
+            aiApiKey: 'key',
+        );
+
+        $provider = new OllamaProvider($config);
+
+        $this->assertFalse($provider->isAvailable());
+    }
+
+    private function createMockContext(): RuntimeContext
+    {
+        $exception = new Exception('Test error');
+        $exceptionInfo = ExceptionInfo::fromThrowable($exception);
+
+        return new RuntimeContext(
+            exception: $exceptionInfo,
+            stackTrace: new StackTraceInfo([]),
+            sourceContext: SourceContext::empty(),
+        );
+    }
+}

--- a/tests/Unit/AI/ProviderFactoryTest.php
+++ b/tests/Unit/AI/ProviderFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ClarityPHP\RuntimeInsight\Tests\Unit\AI;
 
 use ClarityPHP\RuntimeInsight\AI\AnthropicProvider;
+use ClarityPHP\RuntimeInsight\AI\OllamaProvider;
 use ClarityPHP\RuntimeInsight\AI\OpenAIProvider;
 use ClarityPHP\RuntimeInsight\AI\ProviderFactory;
 use ClarityPHP\RuntimeInsight\Config;
@@ -42,6 +43,22 @@ final class ProviderFactoryTest extends TestCase
 
         $this->assertInstanceOf(AnthropicProvider::class, $provider);
         $this->assertSame('anthropic', $provider->getName());
+    }
+
+    public function test_create_returns_ollama_provider_when_configured(): void
+    {
+        $config = new Config(
+            enabled: true,
+            aiEnabled: true,
+            aiProvider: 'ollama',
+            aiModel: 'llama3.2',
+        );
+
+        $factory = new ProviderFactory();
+        $provider = $factory->create($config);
+
+        $this->assertInstanceOf(OllamaProvider::class, $provider);
+        $this->assertSame('ollama', $provider->getName());
     }
 
     public function test_create_returns_null_for_unknown_provider(): void

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -34,6 +34,7 @@ final class ConfigTest extends TestCase
         $this->assertSame('anthropic', $config->getAIProvider());
         $this->assertSame('claude-sonnet-4-20250514', $config->getAIModel());
         $this->assertSame('test-key', $config->getAIApiKey());
+        $this->assertNull($config->getAIBaseUrl());
         $this->assertSame(10, $config->getAITimeout());
         $this->assertSame(15, $config->getSourceLines());
         $this->assertFalse($config->shouldIncludeRequest());
@@ -94,5 +95,19 @@ final class ConfigTest extends TestCase
 
         $this->assertFalse($configWithoutKey->isAIEnabled());
         $this->assertTrue($configWithKey->isAIEnabled());
+    }
+
+    #[Test]
+    public function it_reads_base_url_from_array(): void
+    {
+        $config = Config::fromArray([
+            'ai' => [
+                'provider' => 'ollama',
+                'model' => 'llama3.2',
+                'base_url' => 'http://localhost:11434',
+            ],
+        ]);
+
+        $this->assertSame('http://localhost:11434', $config->getAIBaseUrl());
     }
 }


### PR DESCRIPTION
- Add AI\OllamaProvider (/api/chat, no API key, configurable base_url)
- Add Config::getAIBaseUrl() and ai.base_url in fromArray
- Register ollama in ProviderFactory
- Add OllamaProviderTest (8 tests) and ProviderFactoryTest for ollama
- Add ConfigTest for base_url from array
- Update README and USAGE with Ollama (Local) docs and config