### PR TITLE
docs: fix inaccuracies and broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Feature suggestions are welcome! Please:
 
 ### Prerequisites
 
-- PHP 8.5+
+- PHP 8.2+
 - Composer 2.x
 - Git
 
@@ -69,7 +69,7 @@ composer test
 composer test:coverage
 
 # Run specific test file
-./vendor/bin/phpunit tests/Unit/ExampleTest.php
+./vendor/bin/phpunit tests/Unit/ConfigTest.php
 ```
 
 ### Static Analysis

--- a/USAGE.md
+++ b/USAGE.md
@@ -186,7 +186,7 @@ class CustomExceptionHandler
         );
         
         // Log or display the explanation
-        if ($explanation->hasExplanation()) {
+        if (! $explanation->isEmpty()) {
             // Your custom handling
         }
     }
@@ -889,7 +889,7 @@ Check API key and network connectivity.
 
 ## Next Steps
 
-- Read the [API Reference](docs/api.md) for programmatic usage
-- Check [Examples](docs/examples/) for common use cases
+- See [Configuration Options](#configuration-options) and [AI Provider Configuration](#ai-provider-configuration) for full setup
+- Use `RendererFactory::forFormat()` and `RuntimeInsightFactory::create()` for programmatic usage (see [README](README.md))
 - Join our [Discord](https://discord.gg/clarityphp) for support
 


### PR DESCRIPTION
- USAGE: hasExplanation() -> !isEmpty() (correct Explanation API)
- USAGE: Next Steps link to existing docs (README, in-doc sections)
- CONTRIBUTING: PHP 8.2+ (match composer.json), real test file example