### PR TITLE
docs: reference v0.1.0 instead of v0.9.0 in cross-links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ User-facing behaviour must stay in sync with the code and packaged config.
 
 - **README.md** — High-level overview, install, quick configuration, architecture summary, and pointers to USAGE for details. Do not duplicate long reference tables here; link to USAGE instead.
 - **USAGE.md** — Authoritative reference: commands, every significant config key, Laravel env names, Symfony YAML, **events** (`EventDispatcherInterface`, `BeforeAnalysisEvent`, `AfterAnalysisEvent`), **webhooks** (payload, HTTP semantics, security). Update the Table of Contents at the top of USAGE.md when you add new `##` sections.
-- **CHANGELOG.md** — Add an entry under `[Unreleased]` for user-visible changes (new config keys, breaking changes, new commands, documentation moves). Release branches move those notes into a dated version section (see **v0.9.0** for the current style).
+- **CHANGELOG.md** — Add an entry under `[Unreleased]` for user-visible changes (new config keys, breaking changes, new commands, documentation moves). Release branches move those notes into a dated version section (see **v0.1.0** for the current style).
 - **roadmap.md** — **Not in git** (see `.gitignore`). Keep a **local** copy for internal planning if you want; do **not** `git add` or commit it. Use **Completed** / **In progress** / **Planned** in your local tables. Ship user-visible direction via **CHANGELOG.md**, issues, or milestones instead.
 - **config/runtime-insight.php** — When adding Laravel config, mirror keys and comments in USAGE’s “Full Configuration Reference” block where applicable.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Transform cryptic runtime errors into human-readable explanations with actionabl
 |----------|----------------|
 | **This README** | Install, quick start, high-level features, configuration sketch, architecture overview, links to deeper topics |
 | **[USAGE.md](USAGE.md)** | Laravel and Symfony integration, all Artisan/console commands, full configuration reference, caching, database and performance context, **root cause analysis** (metadata, `diagnostics`, custom analyzer), **events and `EventDispatcherInterface`**, **webhooks** (env vars, payload, security), AI providers, production hardening, troubleshooting |
-| **[CHANGELOG.md](CHANGELOG.md)** | Notable changes by version (see **v0.9.0** for root cause Phase 2, events, webhooks, Symfony wiring) |
+| **[CHANGELOG.md](CHANGELOG.md)** | Notable changes by version (see **v0.1.0** for root cause Phase 2, events, webhooks, Symfony wiring) |
 | **[CONTRIBUTING.md](CONTRIBUTING.md)** | Local setup, tests, PHPStan, code style, documentation expectations for contributors |
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,6 @@
 # Usage Guide
 
-This guide covers all usage scenarios for Runtime Insight. For a shorter overview, see [README.md](README.md). Release history and upgrade notes are in [CHANGELOG.md](CHANGELOG.md) (latest: **v0.9.0** — root cause `diagnostics`, events, webhooks, Symfony service wiring).
+This guide covers all usage scenarios for Runtime Insight. For a shorter overview, see [README.md](README.md). Release history and upgrade notes are in [CHANGELOG.md](CHANGELOG.md) (latest: **v0.1.0** — root cause `diagnostics`, events, webhooks, Symfony service wiring).
 
 ---
 


### PR DESCRIPTION
CHANGELOG already documents [0.1.0]; align README, USAGE, and CONTRIBUTING.

Made-with: Cursor